### PR TITLE
Feature/add rate limiter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@types/cors": "^2.8.19",
         "cors": "^2.8.5",
         "express": "^5.1.0",
+        "express-rate-limit": "^8.1.0",
         "node-cache": "^5.1.2",
         "zod": "^4.1.5"
       },
@@ -635,6 +636,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.1.0.tgz",
+      "integrity": "sha512-4nLnATuKupnmwqiJc27b4dCFmB/T60ExgmtDD7waf4LdrbJ8CPZzZRHYErDYNhoz+ql8fUdYwM/opf90PoPAQA==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -852,6 +871,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/cors": "^2.8.19",
     "cors": "^2.8.5",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.1.0",
     "node-cache": "^5.1.2",
     "zod": "^4.1.5"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import { config } from "./config.js";
 import current from './routes/current.js';
 import autocomplete from './routes/autocomplete.js';
+import { rateLimit } from 'express-rate-limit';
  
 const PORT = config.port;
 
@@ -11,11 +12,19 @@ if (!PORT) {
     process.exit(1);
 }
 
+const limiter = rateLimit({
+	windowMs: 15 * 60 * 1000, // 15 min
+	limit: 100, // 100 requests
+	standardHeaders: 'draft-8',
+	legacyHeaders: false,
+});
+
 const app = express();
 
 // middleware
 app.use(cors());
 app.use(express.json());
+app.use(limiter);
 
 // routes
 app.use('/api/weather', current);


### PR DESCRIPTION
Added express-rate-limit limiter to protect api from overuse.

Current policy allows 100 requests per 15 minute window.